### PR TITLE
(maint) Add a method, find, that returns a canonical form.

### DIFF
--- a/lib/debian_codename.rb
+++ b/lib/debian_codename.rb
@@ -65,16 +65,45 @@ module DebianCodename
 
   module_function
 
+  # Convert from version string to codename and vice versa
   def fast_find(user_search_string)
     search_string = user_search_string.downcase
 
     [DEBIAN_CODENAMES, UBUNTU_CODENAMES].each do |code_catalog|
-      return code_catalog[search_string][0] if code_catalog.key?(search_string)
+      return codename(code_catalog, search_string) if code_catalog.key?(search_string)
 
-      key = code_catalog.find { |_key, value| value[0] == search_string }
-      return key.first unless key.nil?
+      version_found = code_catalog.find { |_, value| value[0] == search_string }
+      return version_found.first unless version_found.nil?
     end
 
     raise DebianCodenameError, 'No match'
+  end
+
+  # Return a canonical form (Hash with ':version' and ':codename' keys)
+  def find(user_search_string)
+    search_string = user_search_string.downcase
+
+    [DEBIAN_CODENAMES, UBUNTU_CODENAMES].each do |code_catalog|
+      if code_catalog.key?(search_string)
+        return {
+          version: search_string,
+          codename: codename(code_catalog, search_string)
+        }
+      end
+
+      version_found = code_catalog.find { |_, value| value[0] == search_string }
+      unless version_found.nil?
+        return {
+          version: version_found.first,
+          codename: search_string
+        }
+      end
+    end
+
+    raise DebianCodenameError, 'No match'
+  end
+
+  def codename(code_catalog, version_string)
+    code_catalog[version_string][0]
   end
 end

--- a/spec/debian_codename_spec.rb
+++ b/spec/debian_codename_spec.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe DebianCodename do
-  it 'can convert release number to codename' do
+  it 'can convert version string to codename' do
     expect(DebianCodename.fast_find('20.10')).to eq('groovy')
   end
 
-  it 'can convert codename to release number' do
+  it 'can convert codename to version string' do
     expect(DebianCodename.fast_find('groovy')).to eq('20.10')
+  end
+
+  it 'can convert codename to canonical form' do
+    expect(DebianCodename.find('groovy')).to eq({ version: '20.10', codename: 'groovy' })
+  end
+
+  it 'can convert version string to canonical form' do
+    expect(DebianCodename.find('20.10')).to eq({ version: '20.10', codename: 'groovy' })
   end
 
   it 'throws DebianCodenameError when nothing is found' do


### PR DESCRIPTION
The `fast_find` method is useful when you know what you have; it just returns the pair.

Add a new method, `find`, that always returns a Hash that labels both the :version and
the corresponding :codename